### PR TITLE
Use newest websocket-stream version

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
   ],
   "dependencies": {
     "pouch-stream-multi-sync": "^0.3.0",
-    "websocket-stream": "^2.1.0"
+    "websocket-stream": "^3.2.1"
   },
   "devDependencies": {
     "code": "^2.0.1",


### PR DESCRIPTION
The old websocket-stream version depends on ws version "^0.8.0".
In large sync pushes (500docs +)  this version sometimes missed a newline in the recieved frames which leads to a json parse error as to frames are parsed as one.
After the update i can no longer reproduce this.